### PR TITLE
Add appointment scheduling stories

### DIFF
--- a/virtual_stories/stories/hospitality/appointment_scheduling/2_weekend_getaway_inquiry_en.txt
+++ b/virtual_stories/stories/hospitality/appointment_scheduling/2_weekend_getaway_inquiry_en.txt
@@ -1,0 +1,123 @@
+"""
+Guest checks last-minute weekend availability and asks for room options.
+ROLES: user (guest planning spontaneous weekend trip), assistant (reservations agent checking options)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "search_room_availability",
+    "description": "Check room availability for given dates, guest count, and optional room type.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier (e.g., skyline_city_hotel_nyc)." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "num_rooms": { "type": "integer", "minimum": 1, "maximum": 3, "description": "Number of rooms requested." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Preferred room type, if any." }
+      },
+      "required": ["hotel_id", "check_in", "check_out", "guests"]
+    },
+    "strict": true
+  },
+  {
+    "name": "get_rate_quote",
+    "description": "Get a rate quote for a specific room type and dates, including tax and fees.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Room type to quote." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "member_tier": { "type": "string", "enum": ["none", "silver", "gold", "platinum"], "description": "Loyalty tier for discounts, if any." },
+        "promo_code": { "type": "string", "pattern": "^[A-Z0-9_-]{3,16}$", "description": "Optional promotional code." },
+        "refundable": { "type": "boolean", "description": "Whether the quote should be refundable/flexible." },
+        "include_breakfast": { "type": "boolean", "description": "Include daily breakfast in rate plan." }
+      },
+      "required": ["hotel_id", "room_type", "check_in", "check_out", "guests"]
+    },
+    "strict": true
+  },
+  {
+    "name": "hold_reservation",
+    "description": "Place a temporary hold on an available room and return a hold identifier.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Room type to hold." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "num_rooms": { "type": "integer", "minimum": 1, "maximum": 3, "description": "Number of rooms to hold." },
+        "customer_name": { "type": "string", "minLength": 2, "description": "Guest full name for the reservation." },
+        "email": { "type": "string", "format": "email", "description": "Guest email for confirmation." },
+        "phone_e164": { "type": "string", "pattern": "^\\+?[1-9]\\d{1,14}$", "description": "Guest phone number in E.164 format." },
+        "guarantee_method": { "type": "string", "enum": ["credit_card", "deposit", "pay_at_hotel"], "description": "Guarantee method for hold." },
+        "special_requests": { "type": "string", "description": "Optional special requests (crib, high floor, late arrival)." }
+      },
+      "required": ["hotel_id", "room_type", "check_in", "check_out", "guests", "customer_name", "guarantee_method"]
+    },
+    "strict": true
+  },
+  {
+    "name": "confirm_reservation",
+    "description": "Confirm a held reservation and issue a reservation ID.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hold_id": { "type": "string", "description": "Identifier from hold operation." },
+        "payment_token": { "type": "string", "minLength": 8, "description": "Tokenized payment reference for guarantee/charge." },
+        "billing_address": { "type": "string", "description": "Billing address line(s)." }
+      },
+      "required": ["hold_id"]
+    },
+    "strict": true
+  },
+  {
+    "name": "send_confirmation_email",
+    "description": "Send a confirmation email to the guest with itinerary and hotel details.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "to_email": { "type": "string", "format": "email", "description": "Recipient email address." },
+        "subject": { "type": "string", "minLength": 3, "maxLength": 120, "description": "Email subject line." },
+        "body": { "type": "string", "minLength": 1, "maxLength": 5000, "description": "Plaintext email body." },
+        "reservation_id": { "type": "string", "description": "Confirmed reservation identifier to include." }
+      },
+      "required": ["to_email", "subject", "body"]
+    },
+    "strict": true
+  }
+]
+```
+```
+"""
+
+system:
+You are a reservations agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi‑Fi, gym, pool, on-site restaurant. Currency: USD; taxes 14.75% + occupancy tax $3.50/night. Flexible rate: free cancel until 48 hours before check-in; Advance Purchase: non-refundable, 15% off. Incidental hold: $100/night. Parking: $35/night. Pets: up to 2 under 40 lb, $75/stay. Be clear, verify missing details, and only use tools to check availability, quote rates, hold, confirm, and email.
+
+user:
+Hi, any chance you have a room for this weekend?
+
+assistant channel=analysis:
+Confirm dates and guest count, then check availability for a Standard King.
+
+assistant channel=commentary to=tool.search_room_availability:
+{"hotel_id": "skyline_city_hotel_nyc", "check_in": "2025-06-14", "check_out": "2025-06-16", "guests": 1, "num_rooms": 1, "room_type": "standard_king"}
+
+tool.search_room_availability channel=commentary to=assistant:
+{"available": true, "rooms": [{"room_type": "standard_king", "inventory": 3}]}
+
+assistant channel=final:
+Good news—we have Standard King rooms for that weekend. Would you like me to hold one?

--- a/virtual_stories/stories/hospitality/appointment_scheduling/3_family_suite_request_en.txt
+++ b/virtual_stories/stories/hospitality/appointment_scheduling/3_family_suite_request_en.txt
@@ -1,0 +1,122 @@
+"""
+Guest asks about a family suite with breakfast included.
+ROLES: user (parent traveling with family of four), assistant (reservations agent offering suite options)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "search_room_availability",
+    "description": "Check room availability for given dates, guest count, and optional room type.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier (e.g., skyline_city_hotel_nyc)." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "num_rooms": { "type": "integer", "minimum": 1, "maximum": 3, "description": "Number of rooms requested." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Preferred room type, if any." }
+      },
+      "required": ["hotel_id", "check_in", "check_out", "guests"]
+    },
+    "strict": true
+  },
+  {
+    "name": "get_rate_quote",
+    "description": "Get a rate quote for a specific room type and dates, including tax and fees.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Room type to quote." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "member_tier": { "type": "string", "enum": ["none", "silver", "gold", "platinum"], "description": "Loyalty tier for discounts, if any." },
+        "promo_code": { "type": "string", "pattern": "^[A-Z0-9_-]{3,16}$", "description": "Optional promotional code." },
+        "refundable": { "type": "boolean", "description": "Whether the quote should be refundable/flexible." },
+        "include_breakfast": { "type": "boolean", "description": "Include daily breakfast in rate plan." }
+      },
+      "required": ["hotel_id", "room_type", "check_in", "check_out", "guests"]
+    },
+    "strict": true
+  },
+  {
+    "name": "hold_reservation",
+    "description": "Place a temporary hold on an available room and return a hold identifier.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Room type to hold." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "num_rooms": { "type": "integer", "minimum": 1, "maximum": 3, "description": "Number of rooms to hold." },
+        "customer_name": { "type": "string", "minLength": 2, "description": "Guest full name for the reservation." },
+        "email": { "type": "string", "format": "email", "description": "Guest email for confirmation." },
+        "phone_e164": { "type": "string", "pattern": "^\+?[1-9]\d{1,14}$", "description": "Guest phone number in E.164 format." },
+        "guarantee_method": { "type": "string", "enum": ["credit_card", "deposit", "pay_at_hotel"], "description": "Guarantee method for hold." },
+        "special_requests": { "type": "string", "description": "Optional special requests (crib, high floor, late arrival)." }
+      },
+      "required": ["hotel_id", "room_type", "check_in", "check_out", "guests", "customer_name", "guarantee_method"]
+    },
+    "strict": true
+  },
+  {
+    "name": "confirm_reservation",
+    "description": "Confirm a held reservation and issue a reservation ID.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hold_id": { "type": "string", "description": "Identifier from hold operation." },
+        "payment_token": { "type": "string", "minLength": 8, "description": "Tokenized payment reference for guarantee/charge." },
+        "billing_address": { "type": "string", "description": "Billing address line(s)." }
+      },
+      "required": ["hold_id"]
+    },
+    "strict": true
+  },
+  {
+    "name": "send_confirmation_email",
+    "description": "Send a confirmation email to the guest with itinerary and hotel details.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "to_email": { "type": "string", "format": "email", "description": "Recipient email address." },
+        "subject": { "type": "string", "minLength": 3, "maxLength": 120, "description": "Email subject line." },
+        "body": { "type": "string", "minLength": 1, "maxLength": 5000, "description": "Plaintext email body." },
+        "reservation_id": { "type": "string", "description": "Confirmed reservation identifier to include." }
+      },
+      "required": ["to_email", "subject", "body"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are a reservations agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi‑Fi, gym, pool, on-site restaurant. Currency: USD; taxes 14.75% + occupancy tax $3.50/night. Flexible rate: free cancel until 48 hours before check-in; Advance Purchase: non-refundable, 15% off. Incidental hold: $100/night. Parking: $35/night. Pets: up to 2 under 40 lb, $75/stay. Be clear, verify missing details, and only use tools to check availability, quote rates, hold, confirm, and email.
+
+user:
+We’re a family of four looking for a suite with breakfast next month.
+
+assistant channel=analysis:
+Clarify exact dates and then check suite availability with breakfast option.
+
+assistant channel=commentary to=tool.search_room_availability:
+{"hotel_id":"skyline_city_hotel_nyc","check_in":"2025-07-10","check_out":"2025-07-15","guests":4,"num_rooms":1,"room_type":"suite_one_bedroom"}
+
+tool.search_room_availability channel=commentary to=assistant:
+{"available":true,"rooms":[{"room_type":"suite_one_bedroom","inventory":1}]}
+
+assistant channel=final:
+A one-bedroom suite is available for your dates, and we can include breakfast for all four guests. Would you like a detailed quote?

--- a/virtual_stories/stories/hospitality/appointment_scheduling/4_extend_stay_en.txt
+++ b/virtual_stories/stories/hospitality/appointment_scheduling/4_extend_stay_en.txt
@@ -1,0 +1,122 @@
+"""
+Guest wants to extend an existing stay by one night.
+ROLES: user (in-house guest extending stay), assistant (front desk agent checking extension availability)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "search_room_availability",
+    "description": "Check room availability for given dates, guest count, and optional room type.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier (e.g., skyline_city_hotel_nyc)." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "num_rooms": { "type": "integer", "minimum": 1, "maximum": 3, "description": "Number of rooms requested." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Preferred room type, if any." }
+      },
+      "required": ["hotel_id", "check_in", "check_out", "guests"]
+    },
+    "strict": true
+  },
+  {
+    "name": "get_rate_quote",
+    "description": "Get a rate quote for a specific room type and dates, including tax and fees.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Room type to quote." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "member_tier": { "type": "string", "enum": ["none", "silver", "gold", "platinum"], "description": "Loyalty tier for discounts, if any." },
+        "promo_code": { "type": "string", "pattern": "^[A-Z0-9_-]{3,16}$", "description": "Optional promotional code." },
+        "refundable": { "type": "boolean", "description": "Whether the quote should be refundable/flexible." },
+        "include_breakfast": { "type": "boolean", "description": "Include daily breakfast in rate plan." }
+      },
+      "required": ["hotel_id", "room_type", "check_in", "check_out", "guests"]
+    },
+    "strict": true
+  },
+  {
+    "name": "hold_reservation",
+    "description": "Place a temporary hold on an available room and return a hold identifier.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Room type to hold." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "num_rooms": { "type": "integer", "minimum": 1, "maximum": 3, "description": "Number of rooms to hold." },
+        "customer_name": { "type": "string", "minLength": 2, "description": "Guest full name for the reservation." },
+        "email": { "type": "string", "format": "email", "description": "Guest email for confirmation." },
+        "phone_e164": { "type": "string", "pattern": "^\+?[1-9]\d{1,14}$", "description": "Guest phone number in E.164 format." },
+        "guarantee_method": { "type": "string", "enum": ["credit_card", "deposit", "pay_at_hotel"], "description": "Guarantee method for hold." },
+        "special_requests": { "type": "string", "description": "Optional special requests (crib, high floor, late arrival)." }
+      },
+      "required": ["hotel_id", "room_type", "check_in", "check_out", "guests", "customer_name", "guarantee_method"]
+    },
+    "strict": true
+  },
+  {
+    "name": "confirm_reservation",
+    "description": "Confirm a held reservation and issue a reservation ID.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hold_id": { "type": "string", "description": "Identifier from hold operation." },
+        "payment_token": { "type": "string", "minLength": 8, "description": "Tokenized payment reference for guarantee/charge." },
+        "billing_address": { "type": "string", "description": "Billing address line(s)." }
+      },
+      "required": ["hold_id"]
+    },
+    "strict": true
+  },
+  {
+    "name": "send_confirmation_email",
+    "description": "Send a confirmation email to the guest with itinerary and hotel details.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "to_email": { "type": "string", "format": "email", "description": "Recipient email address." },
+        "subject": { "type": "string", "minLength": 3, "maxLength": 120, "description": "Email subject line." },
+        "body": { "type": "string", "minLength": 1, "maxLength": 5000, "description": "Plaintext email body." },
+        "reservation_id": { "type": "string", "description": "Confirmed reservation identifier to include." }
+      },
+      "required": ["to_email", "subject", "body"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are a reservations agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi‑Fi, gym, pool, on-site restaurant. Currency: USD; taxes 14.75% + occupancy tax $3.50/night. Flexible rate: free cancel until 48 hours before check-in; Advance Purchase: non-refundable, 15% off. Incidental hold: $100/night. Parking: $35/night. Pets: up to 2 under 40 lb, $75/stay. Be clear, verify missing details, and only use tools to check availability, quote rates, hold, confirm, and email.
+
+user:
+I’m staying with you now and want to stay one more night.
+
+assistant channel=analysis:
+Confirm current room type and check availability for an extra night.
+
+assistant channel=commentary to=tool.search_room_availability:
+{"hotel_id":"skyline_city_hotel_nyc","check_in":"2025-08-05","check_out":"2025-08-06","guests":1,"num_rooms":1,"room_type":"standard_king"}
+
+tool.search_room_availability channel=commentary to=assistant:
+{"available":true,"rooms":[{"room_type":"standard_king","inventory":2}]}
+
+assistant channel=final:
+We can extend your stay by one night in the same room. Let me know if you’d like me to confirm it.

--- a/virtual_stories/stories/hospitality/appointment_scheduling/5_corporate_rate_inquiry_en.txt
+++ b/virtual_stories/stories/hospitality/appointment_scheduling/5_corporate_rate_inquiry_en.txt
@@ -1,0 +1,122 @@
+"""
+Guest asks about booking multiple rooms with a corporate rate.
+ROLES: user (corporate traveler booking for a team), assistant (reservations agent providing group options)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "search_room_availability",
+    "description": "Check room availability for given dates, guest count, and optional room type.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier (e.g., skyline_city_hotel_nyc)." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "num_rooms": { "type": "integer", "minimum": 1, "maximum": 3, "description": "Number of rooms requested." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Preferred room type, if any." }
+      },
+      "required": ["hotel_id", "check_in", "check_out", "guests"]
+    },
+    "strict": true
+  },
+  {
+    "name": "get_rate_quote",
+    "description": "Get a rate quote for a specific room type and dates, including tax and fees.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Room type to quote." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "member_tier": { "type": "string", "enum": ["none", "silver", "gold", "platinum"], "description": "Loyalty tier for discounts, if any." },
+        "promo_code": { "type": "string", "pattern": "^[A-Z0-9_-]{3,16}$", "description": "Optional promotional code." },
+        "refundable": { "type": "boolean", "description": "Whether the quote should be refundable/flexible." },
+        "include_breakfast": { "type": "boolean", "description": "Include daily breakfast in rate plan." }
+      },
+      "required": ["hotel_id", "room_type", "check_in", "check_out", "guests"]
+    },
+    "strict": true
+  },
+  {
+    "name": "hold_reservation",
+    "description": "Place a temporary hold on an available room and return a hold identifier.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_type": { "type": "string", "enum": ["standard_king", "standard_two_double", "deluxe_king_city_view", "suite_one_bedroom"], "description": "Room type to hold." },
+        "check_in": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-in date." },
+        "check_out": { "type": "string", "format": "date", "description": "YYYY-MM-DD check-out date." },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 6, "description": "Total number of guests." },
+        "num_rooms": { "type": "integer", "minimum": 1, "maximum": 3, "description": "Number of rooms to hold." },
+        "customer_name": { "type": "string", "minLength": 2, "description": "Guest full name for the reservation." },
+        "email": { "type": "string", "format": "email", "description": "Guest email for confirmation." },
+        "phone_e164": { "type": "string", "pattern": "^\+?[1-9]\d{1,14}$", "description": "Guest phone number in E.164 format." },
+        "guarantee_method": { "type": "string", "enum": ["credit_card", "deposit", "pay_at_hotel"], "description": "Guarantee method for hold." },
+        "special_requests": { "type": "string", "description": "Optional special requests (crib, high floor, late arrival)." }
+      },
+      "required": ["hotel_id", "room_type", "check_in", "check_out", "guests", "customer_name", "guarantee_method"]
+    },
+    "strict": true
+  },
+  {
+    "name": "confirm_reservation",
+    "description": "Confirm a held reservation and issue a reservation ID.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hold_id": { "type": "string", "description": "Identifier from hold operation." },
+        "payment_token": { "type": "string", "minLength": 8, "description": "Tokenized payment reference for guarantee/charge." },
+        "billing_address": { "type": "string", "description": "Billing address line(s)." }
+      },
+      "required": ["hold_id"]
+    },
+    "strict": true
+  },
+  {
+    "name": "send_confirmation_email",
+    "description": "Send a confirmation email to the guest with itinerary and hotel details.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "to_email": { "type": "string", "format": "email", "description": "Recipient email address." },
+        "subject": { "type": "string", "minLength": 3, "maxLength": 120, "description": "Email subject line." },
+        "body": { "type": "string", "minLength": 1, "maxLength": 5000, "description": "Plaintext email body." },
+        "reservation_id": { "type": "string", "description": "Confirmed reservation identifier to include." }
+      },
+      "required": ["to_email", "subject", "body"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are a reservations agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi‑Fi, gym, pool, on-site restaurant. Currency: USD; taxes 14.75% + occupancy tax $3.50/night. Flexible rate: free cancel until 48 hours before check-in; Advance Purchase: non-refundable, 15% off. Incidental hold: $100/night. Parking: $35/night. Pets: up to 2 under 40 lb, $75/stay. Be clear, verify missing details, and only use tools to check availability, quote rates, hold, confirm, and email.
+
+user:
+My team needs three rooms for a conference. Do you have a corporate rate?
+
+assistant channel=analysis:
+Confirm dates and check availability for three rooms, noting corporate rate eligibility.
+
+assistant channel=commentary to=tool.search_room_availability:
+{"hotel_id":"skyline_city_hotel_nyc","check_in":"2025-09-18","check_out":"2025-09-20","guests":3,"num_rooms":3,"room_type":"standard_two_double"}
+
+tool.search_room_availability channel=commentary to=assistant:
+{"available":true,"rooms":[{"room_type":"standard_two_double","inventory":5}]}
+
+assistant channel=final:
+We have three Standard Two Double rooms available, and we can apply a corporate discount with your company ID. Shall I start the booking?


### PR DESCRIPTION
## Summary
- add four new hospitality appointment scheduling stories: weekend getaway inquiry, family suite request, stay extension, and corporate rate booking

## Testing
- `ENVIRONMENT=test PYTEST_IS_RUNNING=true pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa8fb129a483219a765418eec92192