### PR TITLE
Add diverse hospitality dialogues

### DIFF
--- a/virtual_stories/stories/hospitality/babysitting_services/1_babysitting_service_request_en.txt
+++ b/virtual_stories/stories/hospitality/babysitting_services/1_babysitting_service_request_en.txt
@@ -1,0 +1,57 @@
+"""
+Guest arranges babysitting service and includes small talk.
+ROLES: user (guest needing babysitting), assistant (front desk agent scheduling babysitting)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "schedule_babysitting",
+    "description": "Schedule babysitting services for hotel guests.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "date": { "type": "string", "format": "date", "description": "Date of service." },
+        "start_time": { "type": "string", "pattern": "^\\d{2}:\\d{2}$", "description": "Start time HH:MM." },
+        "duration_hours": { "type": "integer", "minimum": 1, "description": "Duration in hours." },
+        "child_count": { "type": "integer", "minimum": 1, "description": "Number of children." }
+      },
+      "required": ["hotel_id", "date", "start_time", "duration_hours", "child_count"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for babysitting arrangements.
+
+user:
+Hi! We're planning a night out. Could we arrange babysitting for two kids tomorrow at 7:00 PM for three hours? Hope your day is treating you well.
+
+assistant channel=analysis:
+Schedule babysitting for two kids tomorrow for 3 hours starting at 7:00 PM. Use tool and respond to small talk.
+
+assistant channel=commentary to=tool.schedule_babysitting:
+{"hotel_id":"skyline_city_hotel_nyc","date":"2025-09-05","start_time":"19:00","duration_hours":3,"child_count":2}
+
+tool.schedule_babysitting channel=commentary to=assistant:
+{"status":"confirmed","sitter_name":"Alex"}
+
+assistant channel=analysis:
+Confirm booking and mention sitter.
+
+assistant channel=final:
+My day's going great, thanks! I've scheduled babysitting for two children tomorrow from 7:00 to 10:00 PM with Alex. Anything else you'd like to know?
+
+user:
+Fantastic, thanks. Do the sitters bring activities for the kids?
+
+assistant channel=analysis:
+Provide info without tool.
+
+assistant channel=final:
+Yes, our sitters bring age-appropriate games and crafts to keep the kids entertained. Enjoy your night out!

--- a/virtual_stories/stories/hospitality/baggage_storage/1_baggage_storage_request_en.txt
+++ b/virtual_stories/stories/hospitality/baggage_storage/1_baggage_storage_request_en.txt
@@ -1,0 +1,55 @@
+"""
+Guest wants to store luggage after checkout and chats briefly.
+ROLES: user (guest needing baggage storage), assistant (front desk agent arranging storage)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "arrange_baggage_storage",
+    "description": "Arrange complimentary baggage storage for a departing guest.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "num_bags": { "type": "integer", "minimum": 1, "description": "Number of bags to store." },
+        "pickup_time": { "type": "string", "pattern": "^\\d{2}:\\d{2}$", "description": "Expected pick-up time HH:MM." }
+      },
+      "required": ["hotel_id", "num_bags", "pickup_time"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for baggage storage.
+
+user:
+Good morning! Hope you're doing well. I'm checking out but need to store two suitcases until 5:00 PM.
+
+assistant channel=analysis:
+Store two bags until 5:00 PM. Use tool and acknowledge greeting.
+
+assistant channel=commentary to=tool.arrange_baggage_storage:
+{"hotel_id":"skyline_city_hotel_nyc","num_bags":2,"pickup_time":"17:00"}
+
+tool.arrange_baggage_storage channel=commentary to=assistant:
+{"status":"confirmed","ticket_number":"BG123"}
+
+assistant channel=analysis:
+Confirm storage and provide ticket info.
+
+assistant channel=final:
+I'm doing well, thank you! We've stored your two bags and your claim ticket is BG123. They’ll be ready for pickup at 5:00 PM. Anything else I can help with?
+
+user:
+That's all, thanks! Do you charge for the storage?
+
+assistant channel=analysis:
+Answer question; no tool required.
+
+assistant channel=final:
+Baggage storage is complimentary for our guests, so there’s no charge. Enjoy your day!

--- a/virtual_stories/stories/hospitality/business_center/1_business_center_hours_en.txt
+++ b/virtual_stories/stories/hospitality/business_center/1_business_center_hours_en.txt
@@ -1,0 +1,53 @@
+"""
+Guest asks about business center hours and makes small talk.
+ROLES: user (guest needing business center), assistant (front desk agent providing information)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "get_business_center_hours",
+    "description": "Retrieve operating hours for the hotel's business center.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." }
+      },
+      "required": ["hotel_id"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for business center inquiries.
+
+user:
+Good afternoon! Do you know when the business center closes? Need to print a few things. How's your day?
+
+assistant channel=analysis:
+Guest wants business center hours and asks about my day. Use tool to fetch hours and respond.
+
+assistant channel=commentary to=tool.get_business_center_hours:
+{"hotel_id":"skyline_city_hotel_nyc"}
+
+tool.get_business_center_hours channel=commentary to=assistant:
+{"open":"00:00","close":"23:59"}
+
+assistant channel=analysis:
+Confirm hours and answer small talk.
+
+assistant channel=final:
+My day's going well, thanks! Our business center is open 24 hours, so feel free to stop by whenever you're ready to print.
+
+user:
+Perfect, thanks. Do they have coffee there?
+
+assistant channel=analysis:
+Provide info from memory; no tool required.
+
+assistant channel=final:
+Yes, there's a self-service coffee machine inside the business center for guests. Let us know if you need help with anything else.

--- a/virtual_stories/stories/hospitality/currency_exchange/1_currency_exchange_inquiry_en.txt
+++ b/virtual_stories/stories/hospitality/currency_exchange/1_currency_exchange_inquiry_en.txt
@@ -1,0 +1,54 @@
+"""
+Guest inquires about currency exchange and engages in small talk.
+ROLES: user (guest needing currency exchange), assistant (front desk agent providing currency service info)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "check_currency_exchange",
+    "description": "Check if the hotel can exchange a given currency and provide the rate.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "currency_code": { "type": "string", "pattern": "^[A-Z]{3}$", "description": "ISO currency code to exchange." }
+      },
+      "required": ["hotel_id", "currency_code"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for currency exchange inquiries.
+
+user:
+Hi there! Hope you're doing well. Do you exchange euros at the front desk?
+
+assistant channel=analysis:
+Guest asks about exchanging euros (EUR). Use tool and acknowledge greeting.
+
+assistant channel=commentary to=tool.check_currency_exchange:
+{"hotel_id":"skyline_city_hotel_nyc","currency_code":"EUR"}
+
+tool.check_currency_exchange channel=commentary to=assistant:
+{"available":true,"rate":1.07}
+
+assistant channel=analysis:
+Confirm availability and rate, respond warmly.
+
+assistant channel=final:
+I'm doing great, thanks! Yes, we can exchange euros at the front desk. Today's rate is about 1 EUR to 1.07 USD. Stop by anytime if you'd like to swap some currency.
+
+user:
+Awesome, thanks for the info. See you later.
+
+assistant channel=analysis:
+Wrap up with friendly note; no tool.
+
+assistant channel=final:
+You're welcome! Looking forward to seeing you later.

--- a/virtual_stories/stories/hospitality/meeting_equipment/1_projector_request_en.txt
+++ b/virtual_stories/stories/hospitality/meeting_equipment/1_projector_request_en.txt
@@ -1,0 +1,58 @@
+"""
+Guest reserves projector for meeting and engages in friendly chat.
+ROLES: user (guest hosting meeting), assistant (front desk agent handling equipment reservations)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "reserve_meeting_equipment",
+    "description": "Reserve meeting equipment for a specified time and room.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "equipment": { "type": "string", "enum": ["projector","whiteboard","conference_phone"], "description": "Type of equipment." },
+        "room_name": { "type": "string", "description": "Meeting room name." },
+        "date": { "type": "string", "format": "date", "description": "YYYY-MM-DD." },
+        "start_time": { "type": "string", "pattern": "^\\d{2}:\\d{2}$", "description": "Start time in HH:MM." },
+        "duration_minutes": { "type": "integer", "minimum": 15, "description": "Duration in minutes." }
+      },
+      "required": ["hotel_id", "equipment", "room_name", "date", "start_time", "duration_minutes"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for meeting equipment reservations.
+
+user:
+Hi! I'm hosting a team meeting tomorrow and love your lobby décor. Can I reserve a projector in the Hudson room for 2:00 PM for two hours on 2025-08-15?
+
+assistant channel=analysis:
+User needs projector in Hudson room on 2025-08-15 at 2 PM for 2 hours. Use tool and acknowledge compliment.
+
+assistant channel=commentary to=tool.reserve_meeting_equipment:
+{"hotel_id":"skyline_city_hotel_nyc","equipment":"projector","room_name":"Hudson","date":"2025-08-15","start_time":"14:00","duration_minutes":120}
+
+tool.reserve_meeting_equipment channel=commentary to=assistant:
+{"status":"reserved"}
+
+assistant channel=analysis:
+Confirm reservation and engage warmly.
+
+assistant channel=final:
+Thank you! The projector is reserved in the Hudson room for 2:00–4:00 PM on August 15. Anything else for your meeting?
+
+user:
+That's perfect, thanks. Hope your day is going smoothly.
+
+assistant channel=analysis:
+Reply with small talk, no tool.
+
+assistant channel=final:
+So far, so good—thanks for asking! We're here if you need anything else.

--- a/virtual_stories/stories/hospitality/minibar_inquiry/1_minibar_restock_request_en.txt
+++ b/virtual_stories/stories/hospitality/minibar_inquiry/1_minibar_restock_request_en.txt
@@ -1,0 +1,54 @@
+"""
+Guest requests minibar restock and makes casual conversation.
+ROLES: user (guest wanting minibar restocked), assistant (front desk agent arranging restock)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "request_minibar_restock",
+    "description": "Send housekeeping to restock a room's minibar.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_number": { "type": "string", "description": "Guest room number." }
+      },
+      "required": ["hotel_id", "room_number"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for minibar requests.
+
+user:
+Hey, how are you doing? My minibar in room 1502 is empty—could someone restock it?
+
+assistant channel=analysis:
+Guest in room 1502 wants minibar restocked and asked how I'm doing. Use tool to request restock and respond warmly.
+
+assistant channel=commentary to=tool.request_minibar_restock:
+{"hotel_id":"skyline_city_hotel_nyc","room_number":"1502"}
+
+tool.request_minibar_restock channel=commentary to=assistant:
+{"status":"scheduled","estimated_minutes":20}
+
+assistant channel=analysis:
+Confirm restock and address small talk.
+
+assistant channel=final:
+I'm doing well, thanks for asking! Housekeeping will restock your minibar within about 20 minutes. Anything else you need?
+
+user:
+That's great, appreciate it. Any suggestions for a late-night snack nearby?
+
+assistant channel=analysis:
+Offer a suggestion without using tools.
+
+assistant channel=final:
+Our lobby café is open until midnight and has great sandwiches, or there's a 24-hour deli across the street if you feel like a short walk.

--- a/virtual_stories/stories/hospitality/quiet_room_request/1_quiet_room_preference_en.txt
+++ b/virtual_stories/stories/hospitality/quiet_room_request/1_quiet_room_preference_en.txt
@@ -1,0 +1,54 @@
+"""
+Guest requests a quiet room away from noise and includes small talk.
+ROLES: user (guest seeking quiet room), assistant (front desk agent noting room preference)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "request_quiet_room",
+    "description": "Mark a reservation with a preference for a quiet room.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "reservation_id": { "type": "string", "description": "Guest reservation identifier." }
+      },
+      "required": ["hotel_id", "reservation_id"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for room preference requests.
+
+user:
+Hello, I'm checking in later under reservation ABC123. I'd love a quiet room away from elevators. How's your day going?
+
+assistant channel=analysis:
+Guest with reservation ABC123 wants a quiet room. Note preference and respond to small talk.
+
+assistant channel=commentary to=tool.request_quiet_room:
+{"hotel_id":"skyline_city_hotel_nyc","reservation_id":"ABC123"}
+
+tool.request_quiet_room channel=commentary to=assistant:
+{"status":"noted"}
+
+assistant channel=analysis:
+Confirm preference and answer small talk.
+
+assistant channel=final:
+My day's going well, thank you! I've noted your preference for a quiet room away from the elevators. We'll do our best to accommodate when you arrive.
+
+user:
+Thanks a lot! Looking forward to a peaceful stay.
+
+assistant channel=analysis:
+Wrap up with friendly response, no tool.
+
+assistant channel=final:
+We're glad to have you staying with us. Safe travels and see you soon!

--- a/virtual_stories/stories/hospitality/room_decor/1_anniversary_room_decor_request_en.txt
+++ b/virtual_stories/stories/hospitality/room_decor/1_anniversary_room_decor_request_en.txt
@@ -1,0 +1,56 @@
+"""
+Guest requests anniversary room decoration and chats with staff.
+ROLES: user (guest celebrating anniversary), assistant (front desk agent arranging room decor)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "schedule_room_decor",
+    "description": "Arrange special room decorations for an occasion.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_number": { "type": "string", "description": "Guest room number." },
+        "occasion": { "type": "string", "enum": ["anniversary","birthday","honeymoon"], "description": "Reason for decor." },
+        "date": { "type": "string", "format": "date", "description": "Date decorations are needed." }
+      },
+      "required": ["hotel_id", "room_number", "occasion", "date"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for room decoration requests.
+
+user:
+Hello, the lobby looks fantastic! I'm in room 1010 and would love some anniversary decorations tomorrow, 2025-09-20.
+
+assistant channel=analysis:
+Guest requests anniversary decor in room 1010 for 2025-09-20 and compliments lobby. Use tool and reply kindly.
+
+assistant channel=commentary to=tool.schedule_room_decor:
+{"hotel_id":"skyline_city_hotel_nyc","room_number":"1010","occasion":"anniversary","date":"2025-09-20"}
+
+tool.schedule_room_decor channel=commentary to=assistant:
+{"status":"scheduled"}
+
+assistant channel=analysis:
+Confirm decor and respond to compliment.
+
+assistant channel=final:
+Thank you! We’ll have anniversary decorations set up in room 1010 tomorrow. Happy early celebration—anything else I can arrange?
+
+user:
+You're the best, thanks. Have a nice evening!
+
+assistant channel=analysis:
+Respond warmly; no tool needed.
+
+assistant channel=final:
+You're very welcome! Enjoy your evening and let us know if you need anything else.

--- a/virtual_stories/stories/hospitality/valet_service/1_valet_parking_request_en.txt
+++ b/virtual_stories/stories/hospitality/valet_service/1_valet_parking_request_en.txt
@@ -1,0 +1,56 @@
+"""
+Guest requests valet to retrieve car and makes small talk.
+ROLES: user (guest needing car from valet), assistant (front desk agent coordinating valet service)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "request_valet_retrieval",
+    "description": "Arrange for a parked vehicle to be retrieved by valet.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "ticket_number": { "type": "string", "description": "Valet ticket number." },
+        "room_number": { "type": "string", "description": "Guest room number." },
+        "pickup_time": { "type": "string", "pattern": "^\\d{2}:\\d{2}$", "description": "Requested time in HH:MM." }
+      },
+      "required": ["hotel_id", "ticket_number", "room_number", "pickup_time"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools for valet requests.
+
+user:
+Hi, it's such a lovely evening! Could I have my car with ticket 457 brought around at 7:00 AM? I'm in room 804.
+
+assistant channel=analysis:
+The guest needs valet to retrieve car ticket 457 at 7:00 AM for room 804. Use tool and reply with friendly tone.
+
+assistant channel=commentary to=tool.request_valet_retrieval:
+{"hotel_id":"skyline_city_hotel_nyc","ticket_number":"457","room_number":"804","pickup_time":"07:00"}
+
+tool.request_valet_retrieval channel=commentary to=assistant:
+{"status":"scheduled"}
+
+assistant channel=analysis:
+Confirm retrieval and engage with small talk.
+
+assistant channel=final:
+We'll have your car ready for you at 7:00 AM, and I'm glad you're enjoying the evening! Anything else before then?
+
+user:
+Great, you're a lifesaver. Hope your night isn't too hectic.
+
+assistant channel=analysis:
+Respond warmly; no tool needed.
+
+assistant channel=final:
+Thanks! It's been a pleasant night so far. If you need anything else, just let us know.

--- a/virtual_stories/stories/hospitality/wake_up_call/1_wake_up_call_request_en.txt
+++ b/virtual_stories/stories/hospitality/wake_up_call/1_wake_up_call_request_en.txt
@@ -1,0 +1,55 @@
+"""
+Guest requests a wake-up call and engages in small talk.
+ROLES: user (guest needing a wake-up call), assistant (front desk agent scheduling the call)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "schedule_wake_up_call",
+    "description": "Schedule a wake-up call for a guest room.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hotel_id": { "type": "string", "description": "Internal hotel identifier." },
+        "room_number": { "type": "string", "description": "Guest room number." },
+        "time": { "type": "string", "pattern": "^\\d{2}:\\d{2}$", "description": "Wake-up time in HH:MM (24-hour) format." }
+      },
+      "required": ["hotel_id", "room_number", "time"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Skyline City Hotel (hotel_id: skyline_city_hotel_nyc). Address: 350 7th Ave, New York, NY 10001. Timezone: America/New_York. Check-in 3:00 PM, check-out 11:00 AM. Amenities: free Wi-Fi, gym, pool, on-site restaurant, 24-hour business center, valet parking, spa, and airport shuttle. Complimentary breakfast 6:00 AM–10:00 AM. Pets up to 40 lb allowed with $75 fee. Currency: USD. Provide warm service and use tools to handle wake-up calls.
+
+user:
+Hey there, how's your evening going? Could you set a wake-up call for 6:30 AM for room 1205?
+
+assistant channel=analysis:
+The guest wants a wake-up call for 6:30 AM in room 1205. Schedule it using the tool and acknowledge the small talk.
+
+assistant channel=commentary to=tool.schedule_wake_up_call:
+{"hotel_id":"skyline_city_hotel_nyc","room_number":"1205","time":"06:30"}
+
+tool.schedule_wake_up_call channel=commentary to=assistant:
+{"scheduled":true}
+
+assistant channel=analysis:
+Confirm the call and respond to small talk.
+
+assistant channel=final:
+My evening's going well, thank you! I've scheduled a wake-up call for 6:30 AM in room 1205. Is there anything else I can do for you tonight?
+
+user:
+That's perfect, thanks. By the way, does the breakfast start early?
+
+assistant channel=analysis:
+Answer about breakfast hours from system info. No tool needed.
+
+assistant channel=final:
+Breakfast is served from 6:00 AM to 10:00 AM on the lobby level, so you'll be set right after your wake-up call. Have a great night!


### PR DESCRIPTION
## Summary
- add wake-up call scheduling with small talk
- enable valet service retrieval request
- support minibar restock, baggage storage, meeting equipment booking, room decor, business center hours, currency exchange, quiet room preference, and babysitting service dialogues

## Testing
- `ENVIRONMENT=test PYTEST_IS_RUNNING=true pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaa2bdc0808321ae377f059e662e44