### PR TITLE
Add diverse hospitality service stories

### DIFF
--- a/virtual_stories/stories/hospitality/car_rental_booking/1_car_rental_reservation_en.txt
+++ b/virtual_stories/stories/hospitality/car_rental_booking/1_car_rental_reservation_en.txt
@@ -1,0 +1,69 @@
+"""
+Guest arranges rental car through the hotel.
+
+ROLES: user (guest needing a rental car), assistant (front desk agent coordinating car rentals)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "book_car_rental",
+    "description": "Reserve a rental car for a hotel guest.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "car_type": {"type": "string"},
+        "pickup_datetime": {"type": "string", "format": "date-time"},
+        "return_datetime": {"type": "string", "format": "date-time"}
+      },
+      "required": ["reservation_id", "car_type", "pickup_datetime", "return_datetime"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are the concierge at Metro Hub Hotel (hotel_id: metro_hub_atl). Address: 500 Peachtree St, Atlanta, GA 30308.
+Timezone: America/New_York. Check-in 3 PM, check-out 11 AM. Amenities include complimentary breakfast,
+a rooftop pool open 6 AM–11 PM, and valet parking for $35 per night. The hotel partners with CityDrive rentals.
+Use tools to arrange vehicles for guests.
+
+user:
+Hello, I need a compact car during my stay. My reservation is RSV777.
+
+assistant channel=analysis:
+Ask for pickup and return details.
+
+assistant channel=final:
+I'd be happy to set that up. What time would you like to pick up the car and when will you return it?
+
+user:
+Pick up tomorrow at 9 AM and return Sunday at 5 PM. Also, the lobby music is really relaxing.
+
+assistant channel=analysis:
+Use tool with reservation RSV777, car_type compact, pickup 2025-09-20T09:00:00, return 2025-09-22T17:00:00. Respond to compliment.
+
+assistant channel=commentary to=tool.book_car_rental:
+{"reservation_id":"RSV777","car_type":"compact","pickup_datetime":"2025-09-20T09:00:00","return_datetime":"2025-09-22T17:00:00"}
+
+tool.book_car_rental channel=commentary to=assistant:
+{"status":"confirmed","confirmation_number":"CAR123"}
+
+assistant channel=analysis:
+Confirm booking and acknowledge comment.
+
+assistant channel=final:
+Your compact car is booked from 9:00 AM tomorrow until 5:00 PM Sunday. Confirmation number is CAR123. Glad you like our music!
+
+user:
+Great, thanks for the help.
+
+assistant channel=analysis:
+Close the conversation.
+
+assistant channel=final:
+You're welcome. Enjoy your time in Atlanta and drive safely.

--- a/virtual_stories/stories/hospitality/electric_kettle_request/1_electric_kettle_request_en.txt
+++ b/virtual_stories/stories/hospitality/electric_kettle_request/1_electric_kettle_request_en.txt
@@ -1,0 +1,67 @@
+"""
+Guest requests an electric kettle delivery.
+
+ROLES: user (guest wanting to make tea), assistant (front desk agent coordinating item delivery)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "request_electric_kettle",
+    "description": "Deliver an electric kettle to a guest room.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "room_number": {"type": "string"}
+      },
+      "required": ["reservation_id", "room_number"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Riverside Inn (hotel_id: riverside_inn_pdx). Address: 123 River St, Portland, OR 97201.
+Timezone: America/Los_Angeles. Check-in 3 PM, check-out 11 AM. Amenities include free Wi-Fi, a riverfront patio open 8 AM–10 PM,
+complimentary breakfast 6–9 AM, loaner electric kettles, and bike rentals for $15 per day.
+Use tools to deliver kettles to rooms.
+
+user:
+Hey, could I get an electric kettle sent to room 414? My reservation is RSV414.
+
+assistant channel=analysis:
+Use request_electric_kettle with RSV414 and room 414.
+
+assistant channel=commentary to=tool.request_electric_kettle:
+{"reservation_id":"RSV414","room_number":"414"}
+
+tool.request_electric_kettle channel=commentary to=assistant:
+{"status":"delivered"}
+
+assistant channel=analysis:
+Confirm delivery.
+
+assistant channel=final:
+An electric kettle is on its way to room 414. Anything else I can help you with?
+
+user:
+No, that's all. The rain outside is surprisingly calming.
+
+assistant channel=analysis:
+Engage in small talk.
+
+assistant channel=final:
+Portland showers have a charm of their own. Enjoy your tea!
+
+user:
+Thanks!
+
+assistant channel=analysis:
+Wrap up courteously.
+
+assistant channel=final:
+You're welcome. Have a cozy evening.

--- a/virtual_stories/stories/hospitality/golf_course_reservation/1_golf_course_booking_en.txt
+++ b/virtual_stories/stories/hospitality/golf_course_reservation/1_golf_course_booking_en.txt
@@ -1,0 +1,68 @@
+"""
+Guest books a tee time at the resort's golf course.
+
+ROLES: user (guest eager to play golf), assistant (activities coordinator booking tee times)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "book_golf_tee_time",
+    "description": "Reserve a tee time for the golf course.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "tee_time": {"type": "string", "format": "date-time"},
+        "players": {"type": "integer", "minimum": 1, "maximum": 4}
+      },
+      "required": ["reservation_id", "tee_time", "players"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are the activities coordinator at Seaside Paradise Resort (hotel_id: seaside_paradise_hnl). Address: 808 Palm Dr, Honolulu, HI 96815.
+Timezone: Pacific/Honolulu. Check-in 3 PM, check-out noon. The resort offers a private beach, 24-hour fitness center,
+a lagoon pool 7 AM–9 PM, free snorkel rentals, and an on-site golf course with tee times from 6 AM–4 PM.
+Use tools to arrange golf tee times.
+
+user:
+Aloha! Can you book a tee time for two this Saturday at 8 AM? My reservation number is RSV8888.
+
+assistant channel=analysis:
+Use book_golf_tee_time with tee_time 2025-09-20T08:00:00, players 2.
+
+assistant channel=commentary to=tool.book_golf_tee_time:
+{"reservation_id":"RSV8888","tee_time":"2025-09-20T08:00:00","players":2}
+
+tool.book_golf_tee_time channel=commentary to=assistant:
+{"status":"confirmed","confirmation_code":"TEE808"}
+
+assistant channel=analysis:
+Confirm booking.
+
+assistant channel=final:
+Your tee time for two is set for Saturday at 8:00 AM. Confirmation code TEE808. Have a great round!
+
+user:
+Mahalo! The ocean view here is breathtaking.
+
+assistant channel=analysis:
+Respond to compliment.
+
+assistant channel=final:
+It truly is a sight. Enjoy the scenery and your game!
+
+user:
+Thanks, see you then.
+
+assistant channel=analysis:
+Close politely.
+
+assistant channel=final:
+You're welcome. Let us know if you need anything else before Saturday.

--- a/virtual_stories/stories/hospitality/helicopter_tour_booking/1_helicopter_tour_booking_en.txt
+++ b/virtual_stories/stories/hospitality/helicopter_tour_booking/1_helicopter_tour_booking_en.txt
@@ -1,0 +1,68 @@
+"""
+Guest reserves a helicopter tour over the city.
+
+ROLES: user (guest wanting scenic helicopter tour), assistant (front desk agent booking tours)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "book_helicopter_tour",
+    "description": "Book seats on a helicopter tour leaving from the hotel helipad.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "tour_time": {"type": "string", "format": "date-time"},
+        "passengers": {"type": "integer", "minimum": 1, "maximum": 6}
+      },
+      "required": ["reservation_id", "tour_time", "passengers"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are the front desk agent at Sunset Boulevard Hotel (hotel_id: sunset_blvd_la). Address: 700 Sunset Blvd, Los Angeles, CA 90028.
+Timezone: America/Los_Angeles. Amenities include a rooftop pool 9 AM–9 PM, spa 10 AM–7 PM, helipad with city helicopter tours daily at 5 PM and 7 PM,
+valet parking $50 per night, and a 24-hour diner. Check-in 3 PM, check-out noon.
+Use tools to arrange helicopter tours.
+
+user:
+Hi, I'd like to book the 7 PM helicopter tour for three guests tomorrow. Reservation RSV321.
+
+assistant channel=analysis:
+Use book_helicopter_tour with tour_time 2025-09-18T19:00:00, passengers 3.
+
+assistant channel=commentary to=tool.book_helicopter_tour:
+{"reservation_id":"RSV321","tour_time":"2025-09-18T19:00:00","passengers":3}
+
+tool.book_helicopter_tour channel=commentary to=assistant:
+{"status":"confirmed","booking_code":"HEL777"}
+
+assistant channel=analysis:
+Confirm booking.
+
+assistant channel=final:
+Your helicopter tour for three is confirmed for tomorrow at 7:00 PM. Booking code HEL777. Anything else I can do?
+
+user:
+That's all. The lobby art is really cool, by the way.
+
+assistant channel=analysis:
+Respond to small talk.
+
+assistant channel=final:
+Thank you! We feature local artists each season. Enjoy the tour and the art.
+
+user:
+Looking forward to it.
+
+assistant channel=analysis:
+Wrap up.
+
+assistant channel=final:
+Have a fantastic evening at Sunset Boulevard Hotel.

--- a/virtual_stories/stories/hospitality/in_room_movie_rental/1_in_room_movie_rental_en.txt
+++ b/virtual_stories/stories/hospitality/in_room_movie_rental/1_in_room_movie_rental_en.txt
@@ -1,0 +1,67 @@
+"""
+Guest rents an on-demand movie to watch in their room.
+
+ROLES: user (guest wanting to rent a movie), assistant (front desk agent processing movie rentals)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "rent_movie",
+    "description": "Add an on-demand movie charge to the guest's room.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "movie_title": {"type": "string"}
+      },
+      "required": ["reservation_id", "movie_title"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are the front desk agent at Mountain View Lodge (hotel_id: mountain_view_den). Address: 400 Alpine Rd, Denver, CO 80202.
+Timezone: America/Denver. Check-in 3 PM, check-out 11 AM. Amenities include a fireplace lounge,
+indoor pool 7 AM–10 PM, on-demand movies for $5 each, free parking, and 24-hour front desk service.
+Use tools to process movie rentals.
+
+user:
+Hello, I'd like to rent the movie "Star Adventurers" for tonight. My reservation number is RSV555.
+
+assistant channel=analysis:
+Use rent_movie with RSV555 and "Star Adventurers".
+
+assistant channel=commentary to=tool.rent_movie:
+{"reservation_id":"RSV555","movie_title":"Star Adventurers"}
+
+tool.rent_movie channel=commentary to=assistant:
+{"status":"rented","charge":5}
+
+assistant channel=analysis:
+Confirm rental and charge.
+
+assistant channel=final:
+"Star Adventurers" has been added to your room. A $5 charge will appear on your bill. Enjoy the movie!
+
+user:
+Thanks! The mountain air smells so fresh.
+
+assistant channel=analysis:
+Respond warmly.
+
+assistant channel=final:
+That's one of the best parts of being up here. Have a relaxing night.
+
+user:
+Will do, appreciate it.
+
+assistant channel=analysis:
+Close conversation.
+
+assistant channel=final:
+Anytime. Let us know if you need anything else.

--- a/virtual_stories/stories/hospitality/local_sim_card/1_sim_card_purchase_en.txt
+++ b/virtual_stories/stories/hospitality/local_sim_card/1_sim_card_purchase_en.txt
@@ -1,0 +1,67 @@
+"""
+Guest buys a local SIM card at the hotel.
+
+ROLES: user (traveler needing mobile service), assistant (front desk agent selling SIM cards)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "purchase_sim_card",
+    "description": "Sell a prepaid SIM card to a guest.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "carrier_name": {"type": "string"}
+      },
+      "required": ["reservation_id", "carrier_name"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Sky Tower Suites (hotel_id: sky_tower_sea). Address: 909 Pine St, Seattle, WA 98101.
+Timezone: America/Los_Angeles. Check-in 3 PM, check-out noon. The hotel features a panoramic rooftop lounge,
+a coffee bar open 6 AM–6 PM, 24-hour gym, and sells prepaid SIM cards from major carriers. Parking is $25 per night.
+Use tools to process SIM card purchases.
+
+user:
+Hi there, do you sell local SIM cards? I need one from Emerald Mobile. My reservation is RSV2020.
+
+assistant channel=analysis:
+Use purchase_sim_card with RSV2020 and Emerald Mobile.
+
+assistant channel=commentary to=tool.purchase_sim_card:
+{"reservation_id":"RSV2020","carrier_name":"Emerald Mobile"}
+
+tool.purchase_sim_card channel=commentary to=assistant:
+{"status":"purchased","phone_number":"2065550173"}
+
+assistant channel=analysis:
+Confirm sale and provide number.
+
+assistant channel=final:
+Your Emerald Mobile SIM is ready. The number is 206-555-0173. Anything else I can help you with?
+
+user:
+That's perfect. Seattle's drizzle actually feels kind of cozy.
+
+assistant channel=analysis:
+Engage in small talk.
+
+assistant channel=final:
+It does set the mood for a warm cup from our coffee bar. Enjoy your stay!
+
+user:
+Will do, thanks.
+
+assistant channel=analysis:
+Close conversation.
+
+assistant channel=final:
+You're welcome. Let us know if you need anything else.

--- a/virtual_stories/stories/hospitality/pillow_menu_selection/1_pillow_menu_choice_en.txt
+++ b/virtual_stories/stories/hospitality/pillow_menu_selection/1_pillow_menu_choice_en.txt
@@ -1,0 +1,67 @@
+"""
+Guest selects a pillow from the hotel's pillow menu.
+
+ROLES: user (guest requesting specific pillow), assistant (housekeeping staff arranging pillows)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "order_pillow",
+    "description": "Deliver a specific pillow type to a guest room.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "pillow_type": {"type": "string", "enum": ["feather","memory_foam","hypoallergenic"]}
+      },
+      "required": ["reservation_id", "pillow_type"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are housekeeping at Lakeside Resort & Spa (hotel_id: lakeside_resort_chi). Address: 1000 Lakeshore Dr, Chicago, IL 60611.
+Timezone: America/Chicago. Check-in 4 PM, check-out 11 AM. Amenities include an indoor pool 6 AM–10 PM, spa 9 AM–9 PM,
+a pillow menu featuring feather, memory foam, and hypoallergenic pillows, 24-hour room service, and valet parking at $45 per night.
+Use tools to deliver pillow selections.
+
+user:
+Hello, could I get a memory foam pillow for room 508? My reservation number is RSV508.
+
+assistant channel=analysis:
+Use order_pillow with RSV508 and memory_foam.
+
+assistant channel=commentary to=tool.order_pillow:
+{"reservation_id":"RSV508","pillow_type":"memory_foam"}
+
+tool.order_pillow channel=commentary to=assistant:
+{"status":"on_the_way"}
+
+assistant channel=analysis:
+Confirm delivery.
+
+assistant channel=final:
+A memory foam pillow is on its way to your room. Is there anything else you need?
+
+user:
+That's all, thank you! The lake view is stunning from up here.
+
+assistant channel=analysis:
+Respond to compliment.
+
+assistant channel=final:
+We’re glad you’re enjoying the view. Have a restful night at Lakeside Resort & Spa.
+
+user:
+Thanks again.
+
+assistant channel=analysis:
+Close politely.
+
+assistant channel=final:
+You're very welcome. Sleep well!

--- a/virtual_stories/stories/hospitality/room_temperature_control/1_room_temperature_adjustment_en.txt
+++ b/virtual_stories/stories/hospitality/room_temperature_control/1_room_temperature_adjustment_en.txt
@@ -1,0 +1,66 @@
+"""
+Guest requests adjustment of room temperature.
+
+ROLES: user (guest wanting room climate adjusted), assistant (front desk agent coordinating temperature settings)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "adjust_room_temperature",
+    "description": "Set the thermostat temperature for a guest room in Celsius.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string", "description": "Hotel reservation identifier."},
+        "temperature_celsius": {"type": "number", "minimum": 16, "maximum": 30}
+      },
+      "required": ["reservation_id", "temperature_celsius"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a front desk agent at Desert Mirage Hotel (hotel_id: desert_mirage_phx). Address: 789 Cactus Rd, Phoenix, AZ 85001.
+Timezone: America/Phoenix. Check-in 4 PM, check-out 11 AM. Amenities include a rooftop pool open 8 AM–8 PM, free Wi-Fi,
+a 24/7 gym, and on-site parking for $20 per day. Use tools to handle thermostat adjustments upon guest request.
+
+user:
+Hi! My room feels stuffy. Could you set it to 22 degrees Celsius? My reservation is RSV1205.
+
+assistant channel=analysis:
+The guest wants temperature set to 22°C for reservation RSV1205. Use adjust_room_temperature.
+
+assistant channel=commentary to=tool.adjust_room_temperature:
+{"reservation_id":"RSV1205","temperature_celsius":22}
+
+tool.adjust_room_temperature channel=commentary to=assistant:
+{"status":"set"}
+
+assistant channel=analysis:
+Confirm adjustment with guest.
+
+assistant channel=final:
+The thermostat for your room is now set to 22°C. Is there anything else I can help you with?
+
+user:
+That's perfect, thanks! The desert sunset out my window looks amazing.
+
+assistant channel=analysis:
+Respond to compliment with friendly tone.
+
+assistant channel=final:
+The sunsets here are something special—glad you're enjoying it! Let us know if you need anything else.
+
+user:
+Will do, have a good evening.
+
+assistant channel=analysis:
+Close conversation warmly.
+
+assistant channel=final:
+Thank you, and enjoy your evening at Desert Mirage Hotel.

--- a/virtual_stories/stories/hospitality/wine_tasting_event/1_wine_tasting_registration_en.txt
+++ b/virtual_stories/stories/hospitality/wine_tasting_event/1_wine_tasting_registration_en.txt
@@ -1,0 +1,68 @@
+"""
+Guest signs up for the hotel's rooftop wine tasting.
+
+ROLES: user (guest interested in wine tasting), assistant (concierge handling event registrations)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "register_wine_tasting",
+    "description": "Register guests for the Friday rooftop wine tasting.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "date": {"type": "string", "format": "date"},
+        "party_size": {"type": "integer", "minimum": 1, "maximum": 10}
+      },
+      "required": ["reservation_id", "date", "party_size"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are the concierge at Coastal Breeze Hotel (hotel_id: coastal_breeze_mia). Address: 200 Ocean Dr, Miami, FL 33139.
+Timezone: America/New_York. Check-in 3 PM, check-out noon. The hotel features beach access, a rooftop pool 7 AM–10 PM,
+complimentary breakfast 7–10 AM, a spa 9 AM–8 PM, and wine tastings every Friday at 6 PM on the rooftop patio. Valet parking is $40 per night.
+Use tools to register guests for events.
+
+user:
+Hi, I'd like to join the wine tasting this Friday with my wife. Our reservation is RSV2468.
+
+assistant channel=analysis:
+Determine date for upcoming Friday and register two guests.
+
+assistant channel=commentary to=tool.register_wine_tasting:
+{"reservation_id":"RSV2468","date":"2025-09-12","party_size":2}
+
+tool.register_wine_tasting channel=commentary to=assistant:
+{"status":"registered"}
+
+assistant channel=analysis:
+Confirm registration with guest.
+
+assistant channel=final:
+You're all set for the wine tasting this Friday at 6:00 PM for two people. We look forward to seeing you on the rooftop.
+
+user:
+Wonderful, thank you! The ocean breeze here is amazing.
+
+assistant channel=analysis:
+Respond to small talk.
+
+assistant channel=final:
+It's refreshing, isn't it? Enjoy the breeze and let us know if there's anything else you need.
+
+user:
+That's all for now.
+
+assistant channel=analysis:
+Close conversation politely.
+
+assistant channel=final:
+Very good. Have a delightful evening at Coastal Breeze Hotel.

--- a/virtual_stories/stories/hospitality/yoga_mat_checkout/1_yoga_mat_checkout_en.txt
+++ b/virtual_stories/stories/hospitality/yoga_mat_checkout/1_yoga_mat_checkout_en.txt
@@ -1,0 +1,68 @@
+"""
+Guest borrows yoga mats from the hotel.
+
+ROLES: user (guest wanting yoga mats), assistant (front desk agent managing loan items)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+
+TOOLS:
+```json
+[
+  {
+    "name": "checkout_yoga_mat",
+    "description": "Loan yoga mats to guests with a return date.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": {"type": "string"},
+        "quantity": {"type": "integer", "minimum": 1, "maximum": 4},
+        "return_date": {"type": "string", "format": "date"}
+      },
+      "required": ["reservation_id", "quantity", "return_date"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+system:
+You are a concierge at Garden Plaza Hotel (hotel_id: garden_plaza_ldn). Address: 50 Green St, London W1K 6DN, UK.
+Timezone: Europe/London. Check-in 2 PM, check-out 11 AM. The hotel offers a courtyard garden, tea lounge,
+a gym 6 AM–11 PM, and complimentary breakfast 7–10 AM. Yoga mats may be borrowed for 24 hours.
+Use tools to log yoga mat loans.
+
+user:
+Hi, could I borrow two yoga mats for tomorrow morning? I'm RSV4545.
+
+assistant channel=analysis:
+Ask for return date and then loan mats.
+
+assistant channel=final:
+Absolutely. When will you be able to return them?
+
+user:
+We'll bring them back tomorrow evening. The garden smells wonderful, by the way.
+
+assistant channel=analysis:
+Use tool with reservation RSV4545, quantity 2, return_date 2025-09-21. Respond to compliment.
+
+assistant channel=commentary to=tool.checkout_yoga_mat:
+{"reservation_id":"RSV4545","quantity":2,"return_date":"2025-09-21"}
+
+tool.checkout_yoga_mat channel=commentary to=assistant:
+{"status":"checked_out"}
+
+assistant channel=analysis:
+Confirm loan and address comment.
+
+assistant channel=final:
+Two yoga mats are reserved for you and due back tomorrow evening. The garden's lavender is in bloom—glad you noticed!
+
+user:
+Thanks, that's great.
+
+assistant channel=analysis:
+Close conversation.
+
+assistant channel=final:
+You're welcome. Enjoy your practice.


### PR DESCRIPTION
## Summary
- expand hospitality dataset with ten new topics from room temperature adjustments to helicopter tour bookings
- include unique hotel details and tools for each scenario

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa6ab89f08321a2e9991074a077f2