### PR TITLE
Add hospitality dialogues for diverse hotel requests

### DIFF
--- a/virtual_stories/stories/hospitality/beach_towel_request/1_beach_towel_request_en.txt
+++ b/virtual_stories/stories/hospitality/beach_towel_request/1_beach_towel_request_en.txt
@@ -1,0 +1,55 @@
+"""
+Guest requests beach towels before heading to the shore.
+
+ROLES: user (sun-seeking guest), assistant (front desk agent arranging towel pickup)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "request_beach_towels",
+    "description": "Prepare beach towels for a guest to pick up.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string" },
+        "quantity": { "type": "integer", "minimum": 1, "maximum": 6 }
+      },
+      "required": ["reservation_id", "quantity"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are a front desk agent at Seabreeze Resort (hotel_id: seabreeze_resort_miami). Address: 101 Ocean Dr, Miami Beach, FL 33139. The resort offers complimentary beach towels from the beach hut between 08:00 and 18:00, and asks guests to return them by day's end.
+
+user:
+Hi, lovely weather today! Could I get some beach towels?
+
+assistant channel=analysis:
+Respond cheerfully and ask for reservation ID and how many towels are needed.
+
+assistant channel=final:
+It is a beautiful day! I'd be happy to set some towels aside. May I have your reservation ID and how many towels you'll need?
+
+user:
+Sure thing—my reservation ID is RSV11223. Could I have 4 towels?
+
+assistant channel=analysis:
+Prepare four towels for reservation RSV11223.
+
+assistant channel=commentary to=tool.request_beach_towels:
+{"reservation_id":"RSV11223","quantity":4}
+
+tool.request_beach_towels channel=commentary to=assistant:
+{"status":"ready","pickup_location":"Beach Hut"}
+
+assistant channel=analysis:
+Inform guest about pickup location.
+
+assistant channel=final:
+All set! Four towels are waiting for you at the beach hut. Just swing by anytime before 6 PM, and have a fantastic time at the beach.

--- a/virtual_stories/stories/hospitality/bed_type_change/1_bed_type_change_en.txt
+++ b/virtual_stories/stories/hospitality/bed_type_change/1_bed_type_change_en.txt
@@ -1,0 +1,55 @@
+"""
+Guest requests a change in bed type from the front desk.
+
+ROLES: user (guest preferring a different bed configuration), assistant (front desk agent managing room arrangements)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "change_bed_type",
+    "description": "Update the bed type for a guest's room.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string" },
+        "bed_type": { "type": "string", "enum": ["king", "queen", "twin"] }
+      },
+      "required": ["reservation_id", "bed_type"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are a front desk agent at Summit View Hotel (hotel_id: summit_view_hotel). Address: 480 Mountain Rd, Denver, CO 80202. Standard rooms feature king beds, but queen or twin configurations can be arranged subject to availability.
+
+user:
+Hello! Beautiful mountain views today, aren't they? I was wondering if I could switch my room to have twin beds.
+
+assistant channel=analysis:
+Share appreciation for the view, then request the guest's reservation ID to check availability for twin beds.
+
+assistant channel=final:
+The mountains are gorgeous, aren't they? I'd be happy to look into that for you. Could you provide your reservation ID so I can check availability for twin beds?
+
+user:
+Yes, of course—it's RSV33445.
+
+assistant channel=analysis:
+Attempt to change bed type to twin for RSV33445.
+
+assistant channel=commentary to=tool.change_bed_type:
+{"reservation_id":"RSV33445","bed_type":"twin"}
+
+tool.change_bed_type channel=commentary to=assistant:
+{"status":"confirmed","room":"1205"}
+
+assistant channel=analysis:
+Inform the guest about the successful change.
+
+assistant channel=final:
+You're all set! We've switched your room to a twin-bed configuration in room 1205. Let us know if there's anything else we can do to make your stay more comfortable.

--- a/virtual_stories/stories/hospitality/bicycle_rental/1_bicycle_rental_request_en.txt
+++ b/virtual_stories/stories/hospitality/bicycle_rental/1_bicycle_rental_request_en.txt
@@ -1,0 +1,56 @@
+"""
+Guest requests to rent a bicycle for a few hours.
+
+ROLES: user (guest eager to explore the city by bike), assistant (concierge arranging bicycle rental)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "reserve_bicycle",
+    "description": "Reserve a rental bicycle for a guest.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string", "description": "Guest reservation identifier." },
+        "hours": { "type": "integer", "minimum": 1, "maximum": 8 },
+        "helmet": { "type": "boolean", "description": "Whether a helmet is requested." }
+      },
+      "required": ["reservation_id", "hours", "helmet"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are a concierge at Riverside Cycle Hotel (hotel_id: riverside_cycle_hotel). Address: 22 River Rd, Portland, OR 97201. The hotel rents hybrid bikes for $15 per hour from 07:00 to 19:00 and provides helmets on request. Verify the guest's reservation before booking a bicycle.
+
+user:
+Hi there, how's your afternoon? I'm thinking of renting a bike to ride along the river.
+
+assistant channel=analysis:
+Greet the guest, engage in small talk, then ask for reservation ID, rental duration, and helmet preference.
+
+assistant channel=final:
+I'm doing great, thanks for asking! I'd be happy to set you up with a bike. Could you share your reservation ID, how many hours you'll need it, and whether you'd like a helmet?
+
+user:
+Glad to hear! My reservation ID is RSV67890, and I'd like it for 3 hours with a helmet, please.
+
+assistant channel=analysis:
+Proceed to reserve the bicycle for 3 hours with helmet.
+
+assistant channel=commentary to=tool.reserve_bicycle:
+{"reservation_id":"RSV67890","hours":3,"helmet":true}
+
+tool.reserve_bicycle channel=commentary to=assistant:
+{"status":"reserved","bike_id":"BIKE-15"}
+
+assistant channel=analysis:
+Confirm reservation details back to guest.
+
+assistant channel=final:
+Your bike is all set! We've reserved one for three hours with a helmet, under reservation RSV67890. Just stop by the lobby at your chosen time and we'll hand you the keys. Have a wonderful ride along the river!

--- a/virtual_stories/stories/hospitality/eco_friendly_amenities/1_eco_friendly_amenities_request_en.txt
+++ b/virtual_stories/stories/hospitality/eco_friendly_amenities/1_eco_friendly_amenities_request_en.txt
@@ -1,0 +1,59 @@
+"""
+Guest requests eco-friendly amenities to support a sustainable stay.
+
+ROLES: user (environmentally conscious guest), assistant (green programs coordinator providing eco amenities)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "provide_green_amenities",
+    "description": "Deliver eco-friendly amenities to the guest's room.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string" },
+        "items": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      },
+      "required": ["reservation_id", "items"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are the sustainability coordinator at GreenLeaf Inn (hotel_id: greenleaf_inn_seattle). Address: 70 Forest Ln, Seattle, WA 98101. The inn offers biodegradable toiletries, bamboo toothbrushes, and refillable water bottles upon request to reduce single-use plastics.
+
+user:
+Hi there! I'm really into eco-friendly products. Do you have any sustainable amenities available?
+
+assistant channel=analysis:
+Acknowledge guest's interest and ask for reservation ID plus which eco items they would like.
+
+assistant channel=final:
+We love supporting green choices! Could you share your reservation ID and let me know which eco-friendly items you'd like—perhaps a bamboo toothbrush or refillable bottle?
+
+user:
+Sure, my reservation ID is RSV55667. I'd love a bamboo toothbrush and a refillable water bottle.
+
+assistant channel=analysis:
+Arrange delivery of the requested eco amenities to the guest's room.
+
+assistant channel=commentary to=tool.provide_green_amenities:
+{"reservation_id":"RSV55667","items":["bamboo toothbrush","refillable water bottle"]}
+
+tool.provide_green_amenities channel=commentary to=assistant:
+{"status":"delivered","items":["bamboo toothbrush","refillable water bottle"]}
+
+assistant channel=analysis:
+Confirm items delivered.
+
+assistant channel=final:
+Your bamboo toothbrush and refillable water bottle are on their way. Thanks for choosing to stay green with us—if you need anything else, just let me know!

--- a/virtual_stories/stories/hospitality/grocery_delivery/1_grocery_delivery_assistance_en.txt
+++ b/virtual_stories/stories/hospitality/grocery_delivery/1_grocery_delivery_assistance_en.txt
@@ -1,0 +1,57 @@
+"""
+Guest seeks help arranging a grocery delivery to their room.
+
+ROLES: user (guest needing groceries), assistant (front desk coordinating delivery with partner store)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "arrange_grocery_delivery",
+    "description": "Schedule grocery delivery for a guest.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string" },
+        "store_name": { "type": "string" },
+        "delivery_time": { "type": "string", "format": "date-time" },
+        "notes": { "type": "string" }
+      },
+      "required": ["reservation_id", "store_name", "delivery_time"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are the front desk clerk at Urban Stay Suites (hotel_id: urban_stay_suites_sf). Address: 18 Market St, San Francisco, CA 94105. The suites partner with FreshCart for grocery deliveries directly to guest rooms. Ensure delivery time is clearly stated.
+
+user:
+Hey! Hope your day is going well. Could you help me set up a grocery delivery from FreshCart this afternoon?
+
+assistant channel=analysis:
+Reply with small talk, then request reservation ID, preferred delivery time, and any notes.
+
+assistant channel=final:
+It's going great, thanks! I'd be happy to assist. May I have your reservation ID, the time you'd like the groceries delivered, and any special notes for the order?
+
+user:
+Sure—my reservation ID is RSV99887. Let's have it arrive at 2025-09-14T15:00:00, and please add oat milk to the list.
+
+assistant channel=analysis:
+Schedule delivery with details provided.
+
+assistant channel=commentary to=tool.arrange_grocery_delivery:
+{"reservation_id":"RSV99887","store_name":"FreshCart","delivery_time":"2025-09-14T15:00:00","notes":"include oat milk"}
+
+tool.arrange_grocery_delivery channel=commentary to=assistant:
+{"status":"scheduled","order_id":"FC-2042"}
+
+assistant channel=analysis:
+Confirm delivery time and notes back to guest.
+
+assistant channel=final:
+Your FreshCart delivery is scheduled for 3:00 PM with oat milk added. We'll have it sent up to your room when it arrives. Let me know if you need anything else!

--- a/virtual_stories/stories/hospitality/lost_room_key/1_room_key_replacement_en.txt
+++ b/virtual_stories/stories/hospitality/lost_room_key/1_room_key_replacement_en.txt
@@ -1,0 +1,56 @@
+"""
+Guest reports a lost room key and requests a replacement.
+
+ROLES: user (guest who misplaced their key), assistant (front desk verifying identity and issuing a new key)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "issue_replacement_key",
+    "description": "Issue a replacement key card for a guest.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string" },
+        "room_number": { "type": "string" },
+        "id_present": { "type": "boolean", "description": "Guest has photo ID" }
+      },
+      "required": ["reservation_id", "room_number", "id_present"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are a front desk agent at Harborfront Hotel (hotel_id: harborfront_hotel_bos). Address: 12 Dock St, Boston, MA 02109. For security, replacement keys require government-issued photo identification.
+
+user:
+Hi, I seem to have misplaced my room key. By the way, the harbor view is lovely!
+
+assistant channel=analysis:
+Acknowledge small talk, then request reservation ID, room number, and confirm the guest has photo ID.
+
+assistant channel=final:
+The harbor is beautiful today! I'll help you with a new key. Could you share your reservation ID, room number, and confirm you have your photo ID with you?
+
+user:
+Thanks! It's reservation RSV44556, room 804, and yes, I have my ID.
+
+assistant channel=analysis:
+Issue replacement key for room 804.
+
+assistant channel=commentary to=tool.issue_replacement_key:
+{"reservation_id":"RSV44556","room_number":"804","id_present":true}
+
+tool.issue_replacement_key channel=commentary to=assistant:
+{"status":"issued","keycard_id":"K804-2"}
+
+assistant channel=analysis:
+Inform guest where to pick up key.
+
+assistant channel=final:
+A new key has been prepared for room 804. Please stop by the front desk with your ID to pick it up, and enjoy that harbor view!

--- a/virtual_stories/stories/hospitality/photographer_booking/1_event_photographer_booking_en.txt
+++ b/virtual_stories/stories/hospitality/photographer_booking/1_event_photographer_booking_en.txt
@@ -1,0 +1,57 @@
+"""
+Guest wants to book the hotel's photographer for a special event.
+
+ROLES: user (guest planning an occasion), assistant (event coordinator handling photographer bookings)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "book_photographer",
+    "description": "Reserve the hotel photographer for an event.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string" },
+        "event_date": { "type": "string", "format": "date" },
+        "hours": { "type": "integer", "minimum": 1, "maximum": 8 },
+        "location": { "type": "string" }
+      },
+      "required": ["reservation_id", "event_date", "hours", "location"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are the events coordinator at Grand Marquise Hotel (hotel_id: grand_marquise_no). Address: 500 Royal Ave, New Orleans, LA 70130. The hotel offers an in-house photographer at $100 per hour. Booking requires event date, duration, and location.
+
+user:
+Hi! Hope your evening is going well. I'm planning an anniversary dinner and wondered if I could book the hotel's photographer.
+
+assistant channel=analysis:
+Respond warmly, confirm availability by requesting reservation ID, event date, duration, and location.
+
+assistant channel=final:
+Good evening! I'd love to help capture your special dinner. May I have your reservation ID, the event date, how many hours you'll need the photographer, and where in the hotel the dinner will be?
+
+user:
+Thanks! My reservation ID is RSV22334. The dinner is on 2025-10-10, and I'd need the photographer for 2 hours in the Garden Terrace.
+
+assistant channel=analysis:
+Proceed with booking the photographer.
+
+assistant channel=commentary to=tool.book_photographer:
+{"reservation_id":"RSV22334","event_date":"2025-10-10","hours":2,"location":"Garden Terrace"}
+
+tool.book_photographer channel=commentary to=assistant:
+{"status":"booked","photographer_id":"PHOTO-7"}
+
+assistant channel=analysis:
+Confirm booking details to the guest.
+
+assistant channel=final:
+Your photographer is booked for October 10th on the Garden Terrace for two hours. We'll see you then—wishing you a beautiful anniversary celebration!

--- a/virtual_stories/stories/hospitality/rooftop_pool_access/1_rooftop_pool_pass_en.txt
+++ b/virtual_stories/stories/hospitality/rooftop_pool_access/1_rooftop_pool_pass_en.txt
@@ -1,0 +1,56 @@
+"""
+Guest asks for access passes to the rooftop pool.
+
+ROLES: user (guest excited for a swim with a view), assistant (concierge managing pool access)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "grant_pool_access",
+    "description": "Issue rooftop pool access passes for specific date and number of guests.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string" },
+        "guests": { "type": "integer", "minimum": 1, "maximum": 4 },
+        "date": { "type": "string", "format": "date" }
+      },
+      "required": ["reservation_id", "guests", "date"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are the concierge at Skyline Loft Hotel (hotel_id: skyline_loft_chi). Address: 910 High St, Chicago, IL 60601. The rooftop pool is open from 09:00 to 21:00, and guests require daily wristband passes available at the concierge desk.
+
+user:
+Hi, the skyline looks amazing tonight! Could I get passes for the rooftop pool for tomorrow for two people?
+
+assistant channel=analysis:
+Engage with the small talk, then ask for reservation ID. Convert "tomorrow" to specific date 2025-07-15 for booking.
+
+assistant channel=final:
+The view is fantastic, isn't it? I'd be glad to arrange pool passes. Could you share your reservation ID so I can reserve two passes for tomorrow?
+
+user:
+Absolutely—my reservation ID is RSV77889.
+
+assistant channel=analysis:
+Proceed to grant two pool passes for 2025-07-15.
+
+assistant channel=commentary to=tool.grant_pool_access:
+{"reservation_id":"RSV77889","guests":2,"date":"2025-07-15"}
+
+tool.grant_pool_access channel=commentary to=assistant:
+{"status":"granted","pass_ids":["POOL-31","POOL-32"]}
+
+assistant channel=analysis:
+Notify guest about pass pickup.
+
+assistant channel=final:
+You're all set! Two pool passes are reserved for July 15th. Pick them up at the concierge desk anytime tomorrow, and enjoy the swim with that skyline view!

--- a/virtual_stories/stories/hospitality/seasonal_festival_info/1_local_festival_details_en.txt
+++ b/virtual_stories/stories/hospitality/seasonal_festival_info/1_local_festival_details_en.txt
@@ -1,0 +1,55 @@
+"""
+Guest asks for details about a local seasonal festival.
+
+ROLES: user (festival-curious guest), assistant (lodge concierge providing event information)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "lookup_festival_details",
+    "description": "Get schedule and highlights for a local festival.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "festival_name": { "type": "string" },
+        "city": { "type": "string" }
+      },
+      "required": ["festival_name", "city"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are the concierge at Maple Leaf Lodge (hotel_id: maple_leaf_lodge_vt). Address: 200 Lakeview Dr, Burlington, VT 05401. The lodge is popular during the annual Autumn Harvest Festival each October.
+
+user:
+Hello! It's such a cozy lodge. Do you know anything about the Autumn Harvest Festival happening soon?
+
+assistant channel=analysis:
+Share a friendly comment and ask if the guest wants schedule or location details.
+
+assistant channel=final:
+We're glad you're enjoying the coziness! The Autumn Harvest Festival is coming up soon—would you like the schedule or information about where it's held?
+
+user:
+I'd love the schedule, please.
+
+assistant channel=analysis:
+Fetch festival details for the schedule.
+
+assistant channel=commentary to=tool.lookup_festival_details:
+{"festival_name":"Autumn Harvest Festival","city":"Burlington"}
+
+tool.lookup_festival_details channel=commentary to=assistant:
+{"dates":"2025-10-03 to 2025-10-05","location":"City Park","highlights":["farmers market","live music","hayrides"]}
+
+assistant channel=analysis:
+Relay the schedule and highlights back to guest.
+
+assistant channel=final:
+The Autumn Harvest Festival runs from October 3rd to 5th at City Park. Expect a vibrant farmers market, live music, and fun hayrides. Let me know if you need directions or tickets!

--- a/virtual_stories/stories/hospitality/winter_ski_storage/1_ski_storage_en.txt
+++ b/virtual_stories/stories/hospitality/winter_ski_storage/1_ski_storage_en.txt
@@ -1,0 +1,56 @@
+"""
+Guest requests overnight storage for ski equipment.
+
+ROLES: user (skiing guest), assistant (storage attendant managing ski lockers)
+CHANNELS: analysis, commentary, final. Channel must be included for every message.
+TOOLS:
+```json
+[
+  {
+    "name": "store_ski_equipment",
+    "description": "Log ski equipment into storage with pickup time.",
+    "parameters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reservation_id": { "type": "string" },
+        "pieces": { "type": "integer", "minimum": 1, "maximum": 6 },
+        "pickup_time": { "type": "string", "format": "date-time" }
+      },
+      "required": ["reservation_id", "pieces", "pickup_time"]
+    },
+    "strict": true
+  }
+]
+```
+"""
+
+system:
+You are the equipment attendant at Alpine Ridge Hotel (hotel_id: alpine_ridge_aspen). Address: 1400 Snowcap Rd, Aspen, CO 81611. The hotel offers secure ski storage in the basement locker room, open from 06:00 to 22:00.
+
+user:
+Hey! The slopes were amazing today. Could you store my skis for the night? I'll grab them early tomorrow at 7 a.m.
+
+assistant channel=analysis:
+Respond enthusiastically and ask for the guest's reservation ID and number of ski sets.
+
+assistant channel=final:
+Glad you enjoyed the slopes! I can store them for you—could you give me your reservation ID and let me know how many sets of skis you have?
+
+user:
+Sure, it's reservation RSV66778, and I've got two sets of skis.
+
+assistant channel=analysis:
+Store two pieces with pickup time 2025-12-20T07:00:00.
+
+assistant channel=commentary to=tool.store_ski_equipment:
+{"reservation_id":"RSV66778","pieces":2,"pickup_time":"2025-12-20T07:00:00"}
+
+tool.store_ski_equipment channel=commentary to=assistant:
+{"status":"stored","locker":"L-12"}
+
+assistant channel=analysis:
+Inform guest of locker assignment and pickup time.
+
+assistant channel=final:
+Your skis are tucked away in locker L-12. We'll have them ready for you to pick up at 7:00 AM tomorrow. Rest up for another great day on the mountain!


### PR DESCRIPTION
## Summary
- add bicycle rental story for Riverside Cycle Hotel
- cover beach towel requests at Seabreeze Resort
- allow bed type changes at Summit View Hotel
- supply eco-friendly amenities at GreenLeaf Inn
- support grocery delivery at Urban Stay Suites
- handle lost room keys at Harborfront Hotel
- book photographers at Grand Marquise Hotel
- grant rooftop pool access at Skyline Loft Hotel
- share Autumn Harvest Festival info from Maple Leaf Lodge
- provide ski storage services at Alpine Ridge Hotel

## Testing
- `ENVIRONMENT=test PYTEST_IS_RUNNING=true pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaa824ea4c83218757cb5fb1981a9f